### PR TITLE
Update cxf.version to latest patch release of 2.7

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -40,7 +40,7 @@
 
         <osgi.version>4.3.1</osgi.version>
         <osgi.compendium.version>4.3.1</osgi.compendium.version>
-        <cxf.version>2.7.8</cxf.version>
+        <cxf.version>2.7.16</cxf.version>
         <cxf.build-utils.version>2.5.0</cxf.build-utils.version>
         <felix.version>4.2.1</felix.version>
         <spring.version>3.0.6.RELEASE</spring.version>


### PR DESCRIPTION
This small change only changes the CXF version property in the parent project pom to the latest release of CXF 2.7 (2.7.16).
