### PR TITLE
enable 3rd party distribution providers

### DIFF
--- a/dsw/cxf-dsw/pom.xml
+++ b/dsw/cxf-dsw/pom.xml
@@ -124,7 +124,7 @@
                             *
                         </Import-Package>
                         <Export-Package>
-                            !*
+                            org.apache.cxf.dosgi.dsw*,!*
                         </Export-Package>
                         <Bundle-Activator>org.apache.cxf.dosgi.dsw.Activator</Bundle-Activator>
                         

--- a/dsw/cxf-dsw/src/main/java/org/apache/cxf/dosgi/dsw/handlers/ConfigTypeHandlerTracker.java
+++ b/dsw/cxf-dsw/src/main/java/org/apache/cxf/dosgi/dsw/handlers/ConfigTypeHandlerTracker.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.dosgi.dsw.handlers;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.util.tracker.ServiceTracker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConfigTypeHandlerTracker extends ServiceTracker<ConfigurationTypeHandler, ConfigurationTypeHandler> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PojoConfigurationTypeHandler.class);
+    private Map<String, ConfigurationTypeHandler> handlers = new ConcurrentHashMap<String, ConfigurationTypeHandler>();
+
+    public ConfigTypeHandlerTracker(BundleContext context) {
+        super(context, ConfigurationTypeHandler.class, null);
+    }
+
+    @Override
+    public ConfigurationTypeHandler addingService(ServiceReference<ConfigurationTypeHandler> reference) {
+        ConfigurationTypeHandler service = super.addingService(reference);
+        if (service == null) {
+            return null;
+        }
+        String[] configTypes = service.getSupportedTypes();
+        for (String type : configTypes) {
+            LOG.info("Registering new configuration type {} provided by {}", type, service);
+            ConfigurationTypeHandler existing = handlers.put(type, service);
+            if (existing != null) {
+                LOG.warn("Configuration type {} already existed. Replacing...", type);
+            }
+        }
+        return service;
+    }
+
+    @Override
+    public void removedService(ServiceReference<ConfigurationTypeHandler> reference, ConfigurationTypeHandler service) {
+        String[] configTypes = service.getSupportedTypes();
+        for (String type : configTypes) {
+            LOG.info("Removing configuration type {} provided by {}", type, service);
+            handlers.remove(type);
+        }
+        super.removedService(reference, service);
+    }
+
+    /**
+     * tries to find a ConfigurationTypeHandler that supports at least one of the given configuration types
+     * @param configurationTypes
+     * @return a matching ConfigTypeHandler, or <code>null</code>
+     */
+    public ConfigurationTypeHandler getConfigTypeHandler(List<String> configurationTypes) {
+        for (String type : configurationTypes) {
+            ConfigurationTypeHandler handler = handlers.get(type);
+            if (handler != null) {
+                return handler;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * returns a collection of all {@link ConfigurationTypeHandler}s that
+     * have been contributed as an OSGi service
+     * @return all contributed types
+     */
+    public Collection<String> getSupportedTypes() {
+        return handlers.keySet();
+    }
+
+    @Override
+    public void close() {
+        handlers.clear();
+        super.close();
+    }
+
+}

--- a/dsw/cxf-dsw/src/test/java/org/apache/cxf/dosgi/dsw/service/RemoteServiceAdminCoreTest.java
+++ b/dsw/cxf-dsw/src/test/java/org/apache/cxf/dosgi/dsw/service/RemoteServiceAdminCoreTest.java
@@ -101,7 +101,7 @@ public class RemoteServiceAdminCoreTest {
     }
 
     @Test
-    public void testImport() {
+    public void testImport() throws InvalidSyntaxException {
         IMocksControl c = EasyMock.createNiceControl();
         Bundle b = c.createMock(Bundle.class);
         BundleContext bc = c.createMock(BundleContext.class);
@@ -111,6 +111,8 @@ public class RemoteServiceAdminCoreTest {
 
         EasyMock.expect(bc.getBundle()).andReturn(b).anyTimes();
         EasyMock.expect(b.getSymbolicName()).andReturn("BundleName").anyTimes();
+        String serviceFilter = "(objectClass=org.apache.cxf.dosgi.dsw.handlers.ConfigurationTypeHandler)";
+        EasyMock.expect(bc.createFilter(serviceFilter)).andReturn(FrameworkUtil.createFilter(serviceFilter));
 
         Map<String, Object> p = new HashMap<String, Object>();
         p.put(RemoteConstants.ENDPOINT_ID, "http://google.de");
@@ -122,10 +124,10 @@ public class RemoteServiceAdminCoreTest {
         IntentMap intentMap = new IntentMap(new DefaultIntentMapFactory().create());
         IntentManager intentManager = new IntentManagerImpl(intentMap, 10000);
         HttpServiceManager httpServiceManager = c.createMock(HttpServiceManager.class);
+        c.replay();
         ConfigTypeHandlerFactory configTypeHandlerFactory
             = new ConfigTypeHandlerFactory(bc, intentManager, httpServiceManager);
 
-        c.replay();
 
         RemoteServiceAdminCore rsaCore = new RemoteServiceAdminCore(bc, configTypeHandlerFactory) {
             @Override


### PR DESCRIPTION
Allows to provide ConfigurationTypeHandlers as OSGi service to hook in additional distribution providers.

I needed to add package exports, specifically I used those classes when implementing a ConfigurationTypeHandler:

```
import org.apache.cxf.dosgi.dsw.handlers.ConfigurationTypeHandler;
import org.apache.cxf.dosgi.dsw.handlers.ExportResult;
import org.apache.cxf.dosgi.dsw.qos.IntentUnsatisfiedException;
import org.apache.cxf.dosgi.dsw.qos.IntentUtils;
import org.apache.cxf.dosgi.dsw.util.OsgiUtils;

```

If you want to export less packages, please let me know how to adjust the pull request
