### PR TITLE
[DOSGI-267] Treat all intents annotated with @Provider as providers

### DIFF
--- a/provider-rs/src/main/java/org/apache/cxf/dosgi/dsw/handlers/rest/RsProvider.java
+++ b/provider-rs/src/main/java/org/apache/cxf/dosgi/dsw/handlers/rest/RsProvider.java
@@ -32,6 +32,7 @@ import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
 
 import org.apache.aries.rsa.spi.DistributionProvider;
 import org.apache.aries.rsa.spi.Endpoint;
@@ -173,7 +174,8 @@ public class RsProvider extends BaseDistributionProvider implements Distribution
     }
     
     private boolean isProvider(Object intent) {
-        return (intent instanceof ExceptionMapper) // 
+        return intent.getClass().getAnnotation(Provider.class) != null //
+            || (intent instanceof ExceptionMapper) // 
             || (intent instanceof MessageBodyReader) //
             || (intent instanceof MessageBodyWriter) //
             || (intent instanceof ContextResolver) //


### PR DESCRIPTION
Currently a static list of classes is used to determine if a given intent is treated as a provider.  This patch allows any class with the @Provider annotation to be treated as one.